### PR TITLE
fix #5

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -86,6 +86,7 @@ module.exports = argv => {
                 const promises = Promise.all([
                     fs.promises.writeFile(configFilename, JSON.stringify(config, null, 2)),
                     fs.promises.writeFile(secretsFilename, JSON.stringify(secrets, null, 2)),
+                    fs.promises.writeFile('.gitignore', secretsFilename),
                     copy(templateDirectory, process.cwd(), { clobber: false }),
                     initGit()
                 ])

--- a/templates/featured-products/.gitignore
+++ b/templates/featured-products/.gitignore
@@ -1,1 +1,0 @@
-secrets.big-widget.json

--- a/templates/featured-products/.npmignore
+++ b/templates/featured-products/.npmignore
@@ -1,3 +1,0 @@
-# This file exists so that npm will not
-# rename .gitignore to .npmignore in template
-# directories


### PR DESCRIPTION
fix the issue caused by npm transforming .gitignore into .npmignore in templates directories by programmatically generating .gitignore rather than copying it.